### PR TITLE
Update to 20180923

### DIFF
--- a/patches/mono-cert-import.sh
+++ b/patches/mono-cert-import.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+CERTFILE=$SNAP_USER_DATA/certdata.txt
+
+wget -qO $CERTFILE https://hg.mozilla.org/mozilla-central/raw-file/tip/security/nss/lib/ckfw/builtins/certdata.txt
+mono $MONO_OPTIONS $SNAP/usr/lib/mono/4.5/mozroots.exe --import --sync --quiet --file $CERTFILE

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: openra
-version: '20180307'
+version: '20180923'
 summary: Libre/Free Real Time Strategy game engine supporting early Westwood classics
 description: >
   Open Source real-time strategy game engine for early Westwood games
@@ -81,17 +81,21 @@ parts:
   patches:
     plugin: dump
     source: patches
-    prime: [-*]
+    organize:
+      'mono-cert-import.sh': usr/bin/mono-cert-import
+    prime:
+      - -openra-armhf-lua.patch
 
   openra:
     after: [patches, desktop-glib-only]
     plugin: make
-    source: https://github.com/OpenRA/OpenRA/archive/release-$SNAPCRAFT_PROJECT_VERSION.tar.gz
+    source: https://github.com/OpenRA/OpenRA/releases/download/release-$SNAPCRAFT_PROJECT_VERSION/OpenRA-release-$SNAPCRAFT_PROJECT_VERSION-source.tar.bz2
     override-build: |
       patch -Np1 < $SNAPCRAFT_STAGE/openra-armhf-lua.patch
       sed -i 's|^Icon=\(.*\)$|Icon=${SNAP}/usr/local/share/icons/hicolor/128x128/apps/\1.png|' packaging/linux/openra.desktop.in
       sed -i 's|^Exec=|Exec=openra.{MOD}|' packaging/linux/openra.desktop.in
       sed -i 's@\({BIN_DIR}\|{GAME_INSTALL_DIR}\)@$SNAP/\1@g' packaging/linux/openra.in
+      sed -i '2imono-cert-import' packaging/linux/openra.in
       env TRAVIS=1 make dependencies
 
       snapcraftctl build
@@ -114,4 +118,5 @@ parts:
     - libsdl2-2.0-0
     - mono-complete
     - mount
+    - wget
     build-attributes: [no-system-libraries]


### PR DESCRIPTION
Hi Daniel,

Thank you for packaging OpenRA!

OpenRA 20180923 has been released so this is a version bump to the latest release.

- I changed the source url because the *-source.tar.bz2 downloads are already pre-configured with the correct in-game version strings (see [openRA wiki](https://github.com/OpenRA/OpenRA/wiki/Compiling))
- I also made the online multiplayer functionality working in the snap (I got the ['Failed to query server list.' error](https://github.com/OpenRA/OpenRA/wiki/FAQ#failed-to-query-server-list) before).
To fix this the mono certstore is now populated before starting the game.