### PR TITLE
Fix: Failed to query server list

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -89,13 +89,13 @@ parts:
     stage-packages:
       - libglib2.0-bin
 
-  # patches:
-  #   plugin: dump
-  #   source: patches
-  #   organize:
-  #     'mono-cert-import.sh': usr/bin/mono-cert-import
-  #   prime:
-  #     - usr/bin/mono-cert-import
+  patches:
+    plugin: dump
+    source: patches
+    organize:
+      'mono-cert-import.sh': usr/bin/mono-cert-import
+    prime:
+      - usr/bin/mono-cert-import
 
   openra:
     after: [desktop-glib-only]
@@ -105,7 +105,7 @@ parts:
       sed -i 's|^Icon=\(.*\)$|Icon=${SNAP}/usr/local/share/icons/hicolor/128x128/apps/\1.png|' packaging/linux/openra.desktop.in
       sed -i 's|^Exec=|Exec=openra.{MOD}|' packaging/linux/openra.desktop.in
       sed -i 's@\({BIN_DIR}\|{GAME_INSTALL_DIR}\)@$SNAP/\1@g' packaging/linux/openra.in
-      # sed -i '2imono-cert-import' packaging/linux/openra.in
+      sed -i '2imono-cert-import' packaging/linux/openra.in
       env TRAVIS=1 make dependencies
 
       snapcraftctl build


### PR DESCRIPTION
This fixes '[Failed to query server list.](https://github.com/OpenRA/OpenRA/wiki/FAQ#failed-to-query-server-list)' 

On a fresh install of the snap, make sure the Mono cert store is populated with the latest certificates. Else OpenRA will not be able to connect to the OpenRA Master Server (to query for online servers).