### PR TITLE
Add GitHub Actions to build and release snap

### DIFF
--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -1,0 +1,49 @@
+name: Build and Release Snap
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build-stable:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - run: |
+        echo PLAYTEST=false > build-type
+    - uses: diddlesnaps/snapcraft-build-action@remote-builds
+      id: build
+      with:
+        use_launchpad: true
+        launchpad_accept_public_upload: true
+    # - uses: diddlesnaps/snapcraft-review-tools-action@v1
+    #   with:
+    #     snap: ${{ steps.build.outputs.snap }}
+    #     isClassic: 'false'
+    - uses: diddlesnaps/snapcraft-publish-action@multiple-snaps
+      with:
+        store_login: ${{ secrets.STORE_LOGIN }}
+        snap: ${{ steps.build.outputs.snap }}
+        release: beta
+
+  build-playtest:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - run: |
+        echo PLAYTEST=true > build-type
+    - uses: diddlesnaps/snapcraft-build-action@remote-builds
+      id: build
+      with:
+        use_launchpad: true
+        launchpad_accept_public_upload: true
+    # - uses: diddlesnaps/snapcraft-review-tools-action@v1
+    #   with:
+    #     snap: ${{ steps.build.outputs.snap }}
+    #     isClassic: 'false'
+    - uses: diddlesnaps/snapcraft-publish-action@multiple-snaps
+      with:
+        store_login: ${{ secrets.STORE_LOGIN }}
+        snap: ${{ steps.build.outputs.snap }}
+        release: edge

--- a/.github/workflows/release-check.yaml
+++ b/.github/workflows/release-check.yaml
@@ -1,0 +1,27 @@
+name: Check for new releases
+
+on:
+  schedule:
+  - cron: "0 * * * *"
+
+jobs:
+  new-release:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@master
+    - name: get-latest-version
+      run: |
+        VERSION="$(curl https://api.github.com/repos/OpenRA/OpenRA/releases | jq '.[0] | .tag_name' | sed -e 's/"//g')"
+        EDGEVER="$(snap info openra | awk '$1 == "edge:" { print $2 }')"
+        BETAVER="$(snap info openra | ark '$1 == "beta:" { print $2 }')"
+
+        if [ "$VERSION" != "$EDGEVER" ] && [ "$VERSION" != "$BETAVER" ]; then
+          echo "$(date -u --rfc-3339=seconds) Version $VERSION" >> .build.stamp
+        fi
+    - uses: stefanzweifel/git-auto-commit-action@v2.1.0
+      with:
+        commit_message: Trigger build for new version
+        branch: ${{ github.head_ref }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-pull-requests.yaml
+++ b/.github/workflows/test-pull-requests.yaml
@@ -1,0 +1,18 @@
+name: Test-build Snap
+
+on:
+  pull_request:
+
+jobs:
+  build-stable:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - run: |
+        echo PLAYTEST=false > build-type
+    - uses: jhenstridge/snapcraft-build-action@v1
+      id: build
+    - uses: diddlesnaps/snapcraft-review-tools-action@v1
+      with:
+        snap: ${{ steps.build.outputs.snap }}
+        isClassic: 'false'

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 parts
 stage
 prime
+build-type
+*.snap

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,11 +1,10 @@
 name: openra
-version: '20200202'
 summary: Libre/Free Real Time Strategy game engine supporting early Westwood classics
 description: >
   Open Source real-time strategy game engine for early Westwood games
   such as Command & Conquer: Red Alert written in C# using SDL and
   OpenGL. Runs on Windows, Linux, *BSD and Mac OS X.
-
+adopt-info: openra
 grade: stable
 confinement: strict
 base: core18
@@ -15,7 +14,7 @@ architectures:
 - build-on: i386
 - build-on: armhf
 - build-on: arm64
-- build-on: ppc64
+- build-on: ppc64el
 
 layout:
   /usr/share/.mono:
@@ -125,10 +124,25 @@ parts:
     plugin: make
     source: https://github.com/OpenRA/OpenRA/releases/download/release-$SNAPCRAFT_PROJECT_VERSION/OpenRA-release-$SNAPCRAFT_PROJECT_VERSION-source.tar.bz2
     #source: https://github.com/OpenRA/OpenRA.git
+    build-snaps: [jq]
     override-pull: |
-      snapcraftctl pull
+      if [ -f "$SNAPCRAFT_PROJECT_DIR"/build-type ]; then
+        . "$SNAPCRAFT_PROJECT_DIR"/build-type
+      else
+        PLAYTEST=false
+      fi
+      curl -o api.txt https://api.github.com/repos/OpenRA/OpenRA/releases
+
+      JQ_SCRIPT='[.[] | select(.prerelease == '"$PLAYTEST"')] | .[0]'
+      VERSION=$(cat api.txt | jq "$JQ_SCRIPT"' | .tag_name')
+      URL=$(cat api.txt | jq "$JQ_SCRIPT"' | .assets | map(select(.content_type == "application/x-bzip2")) | .[0] | .browser_download_url')
+
+      curl -L "$(echo "$URL" | sed -e 's/"//g')" | tar jx
+
       sed -i 's|^Icon=\(.*\)$|Icon=/usr/local/share/icons/hicolor/128x128/apps/\1.png|;s|^Exec=|Exec=openra.{MOD}|' packaging/linux/openra.desktop.in
       sed -i 's@\({BIN_DIR}\|{GAME_INSTALL_DIR}\)@$SNAP/\1@g' packaging/linux/openra.in
+
+      snapcraftctl set-version "$(echo "$VERSION" | sed -e 's/"//g')"
     override-build: |
       env TRAVIS=1 make dependencies
       env PATH=/usr/local/bin:/usr/local/sbin:/usr/bin:/bin:/usr/sbin:/sbin make


### PR DESCRIPTION
- Add GitHub Actions to build and release
- Add support for playtest builds via GitHub Actions

Signed-off-by: Daniel Llewellyn <daniel@bowlhat.net>