### PR TITLE
Actions: Switch to Podman

### DIFF
--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -26,7 +26,7 @@ jobs:
       uses: diddlesnaps/snapcraft-multiarch-action@v1
       with:
         architecture: ${{ matrix.architecture.arch }}
-        use-podman: ${{ contains(matrix.architecture.runner, 'self-hosted') }}
+        use-podman: 'true'
     - name: Massage the snap name
       id: snap-name
       run: echo "snap=$(echo ${{ steps.build.outputs.snap }} | sed -Ee 's@^'"${GITHUB_WORKSPACE}"'/?@@')" >> "$GITHUB_OUTPUT"
@@ -34,7 +34,7 @@ jobs:
       id: release
       uses: diddlesnaps/snapcraft-multiarch-action@v1
       with:
-        use-podman: ${{ contains(matrix.architecture.runner, 'self-hosted') }}
+        use-podman: 'true'
         store-auth: ${{ secrets.STORE_LOGIN }}
         snapcraft-args: upload --release=beta ${{ steps.snap-name.outputs.snap }}
 
@@ -59,7 +59,7 @@ jobs:
       uses: diddlesnaps/snapcraft-multiarch-action@v1
       with:
         architecture: ${{ matrix.architecture.arch }}
-        use-podman: ${{ contains(matrix.architecture.runner, 'self-hosted') }}
+        use-podman: 'true'
     - name: Massage the snap name
       id: snap-name
       run: echo "snap=$(echo ${{ steps.build.outputs.snap }} | sed -Ee 's@^'"${GITHUB_WORKSPACE}"'/?@@')" >> "$GITHUB_OUTPUT"
@@ -67,6 +67,6 @@ jobs:
       id: release
       uses: diddlesnaps/snapcraft-multiarch-action@v1
       with:
-        use-podman: ${{ contains(matrix.architecture.runner, 'self-hosted') }}
+        use-podman: 'true'
         store-auth: ${{ secrets.STORE_LOGIN }}
         snapcraft-args: upload --release=edge ${{ steps.snap-name.outputs.snap }}

--- a/.github/workflows/build-prs.yml
+++ b/.github/workflows/build-prs.yml
@@ -29,7 +29,7 @@ jobs:
       uses: diddlesnaps/snapcraft-multiarch-action@v1
       with:
         architecture: ${{ matrix.architecture.arch }}
-        use-podman: ${{ contains(matrix.architecture.runner, 'self-hosted') }}
+        use-podman: 'true'
     - name: Review
       if: matrix.architecture.arch == 'amd64'
       uses: diddlesnaps/snapcraft-review-tools-action@v1


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows to simplify the configuration for using Podman in multi-architecture builds. The `use-podman` parameter is now explicitly set to `'true'` instead of relying on a conditional expression.

### Workflow Configuration Updates:

* [`.github/workflows/build-and-release.yaml`](diffhunk://#diff-ad4426c4339c88e5a644696af58c8c29aa5ff4401faf486584641e1a542dff44L29-R37): Replaced the conditional expression `${{ contains(matrix.architecture.runner, 'self-hosted') }}` with a hardcoded `'true'` for the `use-podman` parameter in both `build` and `release` steps for Beta and Edge channels. [[1]](diffhunk://#diff-ad4426c4339c88e5a644696af58c8c29aa5ff4401faf486584641e1a542dff44L29-R37) [[2]](diffhunk://#diff-ad4426c4339c88e5a644696af58c8c29aa5ff4401faf486584641e1a542dff44L62-R70)
* [`.github/workflows/build-prs.yml`](diffhunk://#diff-b54dad9607b51560f8007d8dc2ef6064bf509a7b0b29326c06aad1b9ea304af2L32-R32): Updated the `use-podman` parameter to `'true'` for the `build` step, removing the conditional logic.